### PR TITLE
require scad-mode instead of scad

### DIFF
--- a/scad-preview.el
+++ b/scad-preview.el
@@ -56,7 +56,7 @@
 
 (require 'image-mode)
 (require 'compile)
-(require 'scad "scad-mode")
+(require 'scad-mode)
 
 (defconst scad-preview-version "0.1.1")
 


### PR DESCRIPTION
Upstream now provides the correct feature.
See https://github.com/openscad/openscad/pull/1577.
